### PR TITLE
Revert change to certificate types in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ MotionProvisioning.certificate(platform: platform,
 |Parameter|Description|
 |---------|------|
 |`platform`|`:ios`, `:tvos`, `:mac`|
-|`type`|`:beta`, `:distribution`, `:developer_id` (only mac)|
+|`type`|`:development`, `:distribution`, `:developer_id` (only mac)|
 |`free`|`true` if you want to use a free developer account. Default: `false`|
 
 ```ruby


### PR DESCRIPTION
Development certificate type is still `:development`, not `:beta`.

Reverts rubymotion-community/motion-provisioning#23

Fixes #33 